### PR TITLE
Adding more info to the network (#1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var _defaults = require('lodash').defaults;
 
 function visualize(loopbackApp, options) {
     options = _defaults({}, options, {
-        mountPath: '/visualize'
+        mountPath: '/visualize',
     });
     loopbackApp.use(options.mountPath, createDiagram(loopbackApp, options));
 }
@@ -41,14 +41,15 @@ function prepareJson(app) {
       });
       var modelDefinition = app.models[Model.modelName].definition;
       if (modelDefinition && modelDefinition.properties) {
-          var propString = Object.keys(modelDefinition.properties).toString().split(",").join('<li>');
+          var propString = Object.keys(modelDefinition.properties).toString().split(',').join('<li>');
 
           var propObj = {};
           propObj.id = idx;
-          propObj.name = Model.modelName;
-          propObj.props = propString;
+          propObj.label = Model.modelName;
+          propObj.props = '<ul><li>' + Object.keys(modelDefinition.properties).toString().split(',').join('<li>\n').replace('"', '') + '</ul>';
           propObj.level = level;
-          propObj.remotes = remotes && remotes.toString().split(',').join('<li>');
+          propObj.remotes = remotes && '<ul><li>' + remotes.toString().split(',').join('<li>\n').replace('"', '') + '</ul>';
+          propObj.title = '<h2>' + propObj.label + '</h2><h3>Props:</h3>\n' + propObj.props + '\n<h3>Remotes:</h3>' + propObj.remotes
           propArr.push(propObj);
           x++;
           if (x == 5) {
@@ -64,6 +65,9 @@ function prepareJson(app) {
                   var edgeObj = {};
                   edgeObj.from = modIdxObj[Model.modelName];
                   edgeObj.to = modIdxObj[Model.settings.relations[relArr[rel]].model];
+                  edgeObj.label = relArr[rel] || '';
+                  edgeObj.title = JSON.stringify(Model.settings.relations[relArr[rel]]);
+                  edgeObj.arrows = 'to';
                   edgeArr.push(edgeObj);
               }
           }

--- a/template.ejs
+++ b/template.ejs
@@ -90,17 +90,10 @@ body #header a#logo {
   </div>
 <div id="mynetwork"></div>
 <script type="text/javascript">
-var arr = [];
-<%
-for(var i in nodes) {
-  var node = nodes[i];
-  %>
-  arr.push({id: <%= node.id %>, label: '<%=node.name%>'});
-<%}%>
+
   // create an array with nodes
-    var nodes = new vis.DataSet(arr);
-  //
-  // // create an array with edges
+    var nodes = new vis.DataSet(<%- JSON.stringify(nodes, ["id", "label", "title"]) %>);
+  // create an array with edges
    var edges = new vis.DataSet(<%- JSON.stringify(edges) %>);
 
   // create a network
@@ -127,8 +120,13 @@ for(var i in nodes) {
       strokeColor: '#ffffff',
       align: 'left'
     }
+  },
+  layout: {
+        randomSeed: 2,
+        improvedLayout: true
+    }
   }
-}
+  
   var network = new vis.Network(container, data, options);
 
 </script>

--- a/test/unit-test.js
+++ b/test/unit-test.js
@@ -55,8 +55,8 @@ describe('checkFinalObject', function() {
   it('should compare the finalObject for address and customer.', function(done) {
       var finalObj = visualize.prepareJson(application);
       expect(finalObj.nodes).to.have.lengthOf(2);
-      expect(finalObj.nodes[0]).to.contain.all.keys({'name': 'Address'});
-      expect(finalObj.nodes[0]).to.contain.all.keys({'name': 'Customer'});
+      expect(finalObj.nodes[0]).to.contain.all.keys({'label': 'Address'});
+      expect(finalObj.nodes[0]).to.contain.all.keys({'label': 'Customer'});
       done();
   });
 


### PR DESCRIPTION
I really liked this plugin but I naturally tried mousing-over nodes and edges looking for additional information. Reviewing the code I found there has been some effort in that direction, so I hacked it a little bit.
Perhaps the amount of info shown could be changed by altering module properties... I'm terribly noob at this (js, node, npm, github, loopback, you name it!)

* Changes on index.js:
  * Change node prop names to match expected by vis.js (Vis.js Network graph expects "title" and "label" properties to show tooltip info and node names).
  * Now displaying arrows on edges to show relationship direction bc it seems useful.
  * Lazily showing json stringified additional info on edge tooltips. It would be better to use that information to change arrow heads, color, or something else entirely.
* Changes on template.ejs:
  * It's no longer necessary to build arr[] programatically
  * Chose to set layout seed to a stable value bc it is easier to find nodes around when you're declaring relations in loopback